### PR TITLE
When autoscaling group name matches no instances, avoid passing Insta…

### DIFF
--- a/fabric_aws/__init__.py
+++ b/fabric_aws/__init__.py
@@ -140,6 +140,8 @@ def autoscaling_group_generator(region, autoscaling_group_name, hostname_attribu
     """
 
     instance_ids = autoscaling_group_instance_ids(region, autoscaling_group_name)
+    if not instance_ids:
+        return
 
     hosts = ec2_generator(region,
                           hostname_attribute=hostname_attribute,


### PR DESCRIPTION
…nceIds=[] to the ec2_generator which will select all instances

Fixes Issues #4 